### PR TITLE
Unify test setups

### DIFF
--- a/components/Alert/Alert.test.tsx
+++ b/components/Alert/Alert.test.tsx
@@ -4,17 +4,17 @@ import { render, screen } from "@testing-library/react";
 import { Alert } from "./Alert";
 
 describe("Alert component", () => {
-  test("renders default title when no title is provided", () => {
+  it("renders default title when no title is provided", () => {
     render(<Alert description="Test description" />);
     expect(screen.getByText("Tip!")).toBeDefined();
   });
 
-  test("renders custom title when provided", () => {
+  it("renders custom title when provided", () => {
     render(<Alert title="Custom Title" description="Test description" />);
     expect(screen.getByText("Custom Title")).toBeDefined();
   });
 
-  test("renders description", () => {
+  it("renders description", () => {
     render(<Alert description="Test description" />);
     expect(screen.getByText("Test description")).toBeDefined();
   });

--- a/components/Link/Link.test.tsx
+++ b/components/Link/Link.test.tsx
@@ -5,19 +5,19 @@ import "@testing-library/jest-dom/extend-expect";
 import { Link } from "./Link";
 
 describe("Link component", () => {
-  test("renders with children", () => {
+  it("renders with children", () => {
     render(<Link href="/test">Test Link</Link>);
     const linkElement = screen.getByText("Test Link");
     expect(linkElement).toBeDefined();
   });
 
-  test("renders with href", () => {
+  it("renders with href", () => {
     render(<Link href="/test">Test Link</Link>);
     const linkElement = screen.getByText("Test Link");
     expect(linkElement.closest("a")).toHaveAttribute("href", "/test");
   });
 
-  test("renders with noColor", () => {
+  it("renders with noColor", () => {
     render(
       <Link href="/test" noColor={true}>
         Test Link
@@ -27,7 +27,7 @@ describe("Link component", () => {
     expect(linkElement).toHaveClass("font-regular");
   });
 
-  test("renders with underline", () => {
+  it("renders with underline", () => {
     render(
       <Link href="/test" underline={true}>
         Test Link

--- a/components/Step/Step.test.tsx
+++ b/components/Step/Step.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Step } from "./Step";
 import "@testing-library/jest-dom";
@@ -38,5 +38,23 @@ describe("Step component", () => {
     const stepButton = screen.getByRole("button");
     userEvent.click(stepButton);
     expect(stepButton).toHaveTextContent("1");
+  });
+
+  it("reduces button's opacity when 'isCompleted' state is true", () => {
+    render(<Step {...defaultProps} />);
+    const stepButton = screen.getByRole("button").children[0];
+
+    waitFor(() => expect(stepButton).toHaveClass("opacity-10"));
+    userEvent.click(stepButton);
+    expect(stepButton).not.toHaveClass("opacity-10");
+  });
+
+  it("shows a check icon when 'isCompleted' state is true", () => {
+    render(<Step {...defaultProps} />);
+    const stepButton = screen.getByRole("button");
+    userEvent.click(stepButton);
+    waitFor(() =>
+      expect(screen.getByLabelText("completed")).toBeInTheDocument()
+    );
   });
 });

--- a/components/Step/Step.tsx
+++ b/components/Step/Step.tsx
@@ -30,7 +30,11 @@ export const Step = ({ index, step, completable }: Props) => {
               }`}
             >
               {isCompleted ? (
-                <CheckIcon className="h-6 w-6" aria-hidden="true" />
+                <CheckIcon
+                  className="h-6 w-6"
+                  aria-hidden="true"
+                  aria-label="completed"
+                />
               ) : (
                 index + 1
               )}

--- a/components/Toast/Toast.test.tsx
+++ b/components/Toast/Toast.test.tsx
@@ -11,7 +11,7 @@ describe("<Toast />", () => {
     localStorage.clear();
   });
 
-  test("starts the timer when the start button is clicked", () => {
+  it("starts the timer when the start button is clicked", () => {
     const { getByTestId, getByText } = render(<Toast />);
 
     fireEvent.click(getByTestId("start-btn"));
@@ -23,7 +23,7 @@ describe("<Toast />", () => {
     expect(getByText("00:00:01")).toBeDefined();
   });
 
-  test("pauses the timer when the pause button is clicked", () => {
+  it("pauses the timer when the pause button is clicked", () => {
     const { getByTestId, getByText } = render(<Toast />);
 
     fireEvent.click(getByTestId("start-btn"));
@@ -36,7 +36,7 @@ describe("<Toast />", () => {
     expect(getByText("00:00:00")).toBeDefined();
   });
 
-  test("resumes the timer when the resume button is clicked", () => {
+  it("resumes the timer when the resume button is clicked", () => {
     const { getByTestId, getByText } = render(<Toast />);
 
     fireEvent.click(getByTestId("start-btn"));
@@ -50,7 +50,7 @@ describe("<Toast />", () => {
     expect(getByText("00:00:01")).toBeDefined();
   });
 
-  test("restarts the timer when the restart button is clicked", () => {
+  it("restarts the timer when the restart button is clicked", () => {
     const { getByTestId, getByText } = render(<Toast />);
 
     fireEvent.click(getByTestId("start-btn"));

--- a/components/Toast/hooks/useMobileScrollCheck.test.ts
+++ b/components/Toast/hooks/useMobileScrollCheck.test.ts
@@ -18,7 +18,7 @@ describe("useMobileScrollCheck", () => {
     });
   });
 
-  test("set visibility to true for non small screens", () => {
+  it("set visibility to true for non small screens", () => {
     const setIsVisible = jest.fn();
     window.innerWidth = 800;
 
@@ -26,7 +26,7 @@ describe("useMobileScrollCheck", () => {
     expect(setIsVisible).toHaveBeenCalledWith(true);
   });
 
-  test("does not set visibility for small screens on initial render", () => {
+  it("does not set visibility for small screens on initial render", () => {
     const setIsVisible = jest.fn();
     window.innerWidth = 600;
 
@@ -34,7 +34,7 @@ describe("useMobileScrollCheck", () => {
     expect(setIsVisible).not.toHaveBeenCalled();
   });
 
-  test("sets visibility to true for small screens when scrolling beyond limit", () => {
+  it("sets visibility to true for small screens when scrolling beyond limit", () => {
     const setIsVisible = jest.fn();
     window.innerWidth = 600;
 


### PR DESCRIPTION
## What does this PR introduce?
Currently there's a mix of `test("...")` and `it("...")` tests in the codebase. This PR unifies how tests are written by always using `it("...")`

